### PR TITLE
Add changelog and display option for fork-specific changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this fork will be documented in this file.
+
+## [Unreleased]
+- Add changelog and `--changes` flag to `models/predict.py` to show fork-specific modifications.
+


### PR DESCRIPTION
## Summary
- log fork-specific updates in a new `CHANGELOG.md`
- support `--changes` flag in `models/predict.py` to display the changelog
- mention changelog availability in the script help text

## Testing
- `python models/predict.py --help`
- `python models/predict.py --changes`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9cf54a3988330808550393325ea28