### PR TITLE
Fix feature engineering age calculation for datetime columns

### DIFF
--- a/ufc/preprocessing/feature_engineering.py
+++ b/ufc/preprocessing/feature_engineering.py
@@ -63,8 +63,17 @@ def derive_features(
     if randomise_fighters:
         df = randomize_fighter_order(df, random_state=random_state)
 
-    df["fighter1_age"] = df["event_date"].dt.year - df["fighter1_dob"].dt.year
-    df["fighter2_age"] = df["event_date"].dt.year - df["fighter2_dob"].dt.year
+    # Ensure datetime columns retain their type after any swapping operations
+    for col in ["event_date", "fighter1_dob", "fighter2_dob"]:
+        df[col] = pd.to_datetime(df[col])
+
+    # Compute age of each fighter at the time of the event in fractional years
+    df["fighter1_age"] = (
+        df["event_date"] - df["fighter1_dob"]
+    ).dt.days / 365.25
+    df["fighter2_age"] = (
+        df["event_date"] - df["fighter2_dob"]
+    ).dt.days / 365.25
 
     compare_attributes = [
         'height',


### PR DESCRIPTION
## Summary
- ensure datetime columns retain type after randomizing fighters
- compute fighter ages using date differences

## Testing
- `python models/train_random_forest.py --feature-engineering --n-estimators 10`


------
https://chatgpt.com/codex/tasks/task_e_68abaa0ceb6083309baa62ad1496dc88