### PR TITLE
Allow configurable random state in training split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,5 @@ All notable changes to this fork will be documented in this file.
 
 ## [Unreleased]
 - Add changelog and `--changes` flag to `models/predict.py` to show fork-specific modifications.
+- Allow `models/train_random_forest.py` to use the provided `random_state` for `train_test_split`.
 

--- a/models/train_random_forest.py
+++ b/models/train_random_forest.py
@@ -144,7 +144,7 @@ def train_and_save(
 
     stratify = y if y.value_counts().min() >= 2 else None
     X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.2, random_state=42, stratify=stratify
+        X, y, test_size=0.2, random_state=random_state, stratify=stratify
     )
 
     pipeline = build_pipeline(
@@ -190,7 +190,10 @@ def parse_args():
         help="Minimum number of samples required to be at a leaf node",
     )
     parser.add_argument(
-        "--random-state", type=int, default=42, help="Random seed for reproducibility"
+        "--random-state",
+        type=int,
+        default=42,
+        help="Random seed for reproducibility of data splitting and model",
     )
     parser.add_argument(
         "--feature-engineering",


### PR DESCRIPTION
## Summary
- Use provided `random_state` when splitting training and test data
- Clarify CLI help for `--random-state`
- Document change in changelog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abac6e246c8330b71cb8e36fbbab37