### PR TITLE
Fix mixed datetime handling in feature engineering

### DIFF
--- a/ufc/preprocessing/feature_engineering.py
+++ b/ufc/preprocessing/feature_engineering.py
@@ -64,8 +64,12 @@ def derive_features(
         df = randomize_fighter_order(df, random_state=random_state)
 
     # Ensure datetime columns retain their type after any swapping operations
+    # ``pd.to_datetime`` can raise ``ValueError`` if a column contains a mix of
+    # datetime-like objects and integers (behaviour observed on older Pandas
+    # versions).  Coercing invalid or mixed values to ``NaT`` avoids this while
+    # keeping valid timestamps intact.
     for col in ["event_date", "fighter1_dob", "fighter2_dob"]:
-        df[col] = pd.to_datetime(df[col])
+        df[col] = pd.to_datetime(df[col], errors="coerce")
 
     # Compute age of each fighter at the time of the event in fractional years
     df["fighter1_age"] = (


### PR DESCRIPTION
## Summary
- avoid ValueError when converting datetime columns by coercing mixed values to NaT

## Testing
- `python train_random_forest.py --feature-engineering`

------
https://chatgpt.com/codex/tasks/task_e_68abae22654883308ad398f4cc7ffa05