### PR TITLE
Avoid outcome leakage from betting odds

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Some interesting insights and visualisations are shared here:
     * Fight win streak, finish rate (knockouts, submissions)
     * Derived features - durability, tag as wrester/striker/grappler etc.
     * Include if fighter is favourite (if have scraped odds)
+    * For outcome prediction, betting odds (`favourite_odds`, `underdog_odds`) are excluded to prevent data leakage
 * Note that MMA is a highly dynamic and unpredictable sport, frequently characterised by upsets, and that match outcome may not be consistently predictable
 
 | Process | Analysis | Finding | Notebook |


### PR DESCRIPTION
## Summary
- Drop favourite_odds and underdog_odds when training outcome model to avoid leakage
- Mention odds exclusion in CLI help and documentation

## Testing
- `pytest`
- `python models/train_random_forest.py --n-estimators 50 --max-depth 10 --min-samples-split 2 --min-samples-leaf 1 --random-state 42`

------
https://chatgpt.com/codex/tasks/task_e_68abd0dde01c8330b8ad3d9fed7ca244